### PR TITLE
'public_ip' is deprecated in AWS-SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ set :aws_deploy_roles, [:app, :web, :db]
 set :aws_deploy_user, 'USER FOR SSH CONNECTION'
  
 # optional: defaults to 'public_dns_name'
-# select from ['public_ip', 'public_dns_name', 'private_ip_address', 'private_dns_name']
+# select from ['public_ip_address', 'public_dns_name', 'private_ip_address', 'private_dns_name']
 set :aws_ip_type, 'public_dns_name'
 ```
 

--- a/lib/capistrano/autoscaling_deploy/version.rb
+++ b/lib/capistrano/autoscaling_deploy/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module AutoScalingDeploy
-    VERSION = '1.5'
+    VERSION = '1.6'
   end
 end

--- a/lib/capistrano/helpers/aws_helper.rb
+++ b/lib/capistrano/helpers/aws_helper.rb
@@ -1,7 +1,7 @@
 require 'aws-sdk'
 
 module AwsHelper
-  IP_TYPES = %w(public_ip public_dns_name private_ip_address private_dns_name)
+  IP_TYPES = %w(public_ip_address public_dns_name private_ip_address private_dns_name)
 
   def get_instances(aws_region, aws_access_key_id, aws_secret_access_key, aws_autoscaling_group_name, aws_ip_type)
     aws_credentials = Aws::Credentials.new(aws_access_key_id, aws_secret_access_key)


### PR DESCRIPTION
reference : http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/Instance.html#ip_address-instance_method